### PR TITLE
WIP: add Esperanto translation of the Code of Conduct

### DIFF
--- a/KONDUTKODEKSO.md
+++ b/KONDUTKODEKSO.md
@@ -1,0 +1,25 @@
+# Kondutkodekso
+
+Ni estas kognaj.  
+Esti kogna estas esti limhava.  
+En nia limigo ni faras elektojn, kiuj estas malsaĝaj aŭ estas misaj.
+
+Se ni faras malsaĝajn elektojn pro nia limigeco,  
+ni ne rajtas juĝi aliaj pro la sama kialo.
+
+Do, ni ne povas juĝi,  
+tial ni pardonas.
+
+Tiu ĉi projekte kaj ĝiaj rezultaĵoj estas intencata kiel:  
+loko de lernado,  
+loko de kompreno,  
+loko de instruado,  
+loko de komunigo,  
+loko, kie kreantoj kreas la ilojn por helpi al aliaj kreantoj krei komplikajn aĵojn elegante.
+
+Fartu bone, kreanto. Fartu bone kaj kreu.
+
+---
+
+Surbaze de la [Kodekso de Kreanto v2](https://github.com/Xe/creators-code).
+Bonvolu legi la ligitan retpaĝon por pli da informoj.


### PR DESCRIPTION
Filing as draft, as I'd like the translation to be proofread by more well-versed Esperanto speakers than I am.

[Rendered](https://github.com/das-g/creators-code/blob/Esperanto/KONDUTKODEKSO.md)

## :green_heart: EO: aldonu Esperantan tradukon de la Kondutkodekso

Aldonante kiel malneton, ĉar mi volas, ke Esperantistoj pli spertaj ol mi provlegu la tradukon.

[Bildigita](https://github.com/das-g/creators-code/blob/Esperanto/KONDUTKODEKSO.md)